### PR TITLE
Minor fixes to Makefile.unix

### DIFF
--- a/Makefile.unix
+++ b/Makefile.unix
@@ -1,12 +1,12 @@
 CC=cc -O2 -Wall -Wextra -I./lua/src -DLUA_USE_POSIX `sdl2-config --cflags`
-LIB=`sdl2-config --libs`
+LIB=`sdl2-config --libs` -lm
 OBJ_LUA=./lua/src/lapi.o ./lua/src/lauxlib.o ./lua/src/lbaselib.o ./lua/src/lcode.o ./lua/src/lcorolib.o ./lua/src/lctype.o ./lua/src/ldblib.o ./lua/src/ldebug.o ./lua/src/ldo.o ./lua/src/ldump.o ./lua/src/lfunc.o ./lua/src/lgc.o ./lua/src/linit.o ./lua/src/liolib.o ./lua/src/llex.o ./lua/src/lmathlib.o ./lua/src/lmem.o ./lua/src/loadlib.o ./lua/src/lobject.o ./lua/src/lopcodes.o ./lua/src/loslib.o ./lua/src/lparser.o ./lua/src/lstate.o ./lua/src/lstring.o ./lua/src/lstrlib.o ./lua/src/ltable.o ./lua/src/ltablib.o ./lua/src/ltm.o ./lua/src/lundump.o ./lua/src/lutf8lib.o ./lua/src/lvm.o ./lua/src/lzio.o
 OBJ_SRC=./src/ltro1.o
 OBJ=$(OBJ_LUA) $(OBJ_SRC)
 BIN=ltro1
 
 default: $(OBJ)
-	$(CC) -o $(BIN) $(LIB) $(OBJ)
+	$(CC) $(OBJ) $(LIB) -o $(BIN) 
 
 clean:
 	rm -f $(BIN) $(OBJ)


### PR DESCRIPTION
The current Makefile fails to compile using gcc version 10.2.1 20210110 (Debian 10.2.1-6).

```
shoe@Lee-Workstation:~/ltro1$ make -f Makefile.unix
cc -O2 -Wall -Wextra -I./lua/src -DLUA_USE_POSIX `sdl2-config --cflags` -o ltro1 `sdl2-config --libs` ./lua/src/lapi.o ./lua/src/lauxlib.o ./lua/src/lbaselib.o ./lua/src/lcode.o ./lua/src/lcorolib.o ./lua/src/lctype.o ./lua/src/ldblib.o ./lua/src/ldebug.o ./lua/src/ldo.o ./lua/src/ldump.o ./lua/src/lfunc.o ./lua/src/lgc.o ./lua/src/linit.o ./lua/src/liolib.o ./lua/src/llex.o ./lua/src/lmathlib.o ./lua/src/lmem.o ./lua/src/loadlib.o ./lua/src/lobject.o ./lua/src/lopcodes.o ./lua/src/loslib.o ./lua/src/lparser.o ./lua/src/lstate.o ./lua/src/lstring.o ./lua/src/lstrlib.o ./lua/src/ltable.o ./lua/src/ltablib.o ./lua/src/ltm.o ./lua/src/lundump.o ./lua/src/lutf8lib.o ./lua/src/lvm.o ./lua/src/lzio.o ./src/ltro1.o
/usr/bin/ld: ./src/ltro1.o: in function `f_gain':
ltro1.c:(.text+0x1da): undefined reference to `SDL_LockAudioDevice'
/usr/bin/ld: ltro1.c:(.text+0x209): undefined reference to `SDL_UnlockAudioDevice'
/usr/bin/ld: ./src/ltro1.o: in function `f_clear':
ltro1.c:(.text+0x261): undefined reference to `SDL_FillRect'
/usr/bin/ld: ./src/ltro1.o: in function `f_play':
ltro1.c:(.text+0x501): undefined reference to `SDL_LockAudioDevice'
/usr/bin/ld: ltro1.c:(.text+0x511): undefined reference to `SDL_strlcpy'
/usr/bin/ld: ltro1.c:(.text+0x556): undefined reference to `SDL_UnlockAudioDevice'
/usr/bin/ld: ./src/ltro1.o: in function `f_stop':
ltro1.c:(.text+0x65c): undefined reference to `SDL_LockAudioDevice'
/usr/bin/ld: ltro1.c:(.text+0x686): undefined reference to `SDL_UnlockAudioDevice'
/usr/bin/ld: ./src/ltro1.o: in function `initialize_ltro1':
ltro1.c:(.text+0xcf3): undefined reference to `SDL_memset'
/usr/bin/ld: ltro1.c:(.text+0xcfd): undefined reference to `SDL_Init'
/usr/bin/ld: ltro1.c:(.text+0xd11): undefined reference to `SDL_GetDesktopDisplayMode'
/usr/bin/ld: ltro1.c:(.text+0xda5): undefined reference to `SDL_CreateWindow'
/usr/bin/ld: ltro1.c:(.text+0xdbd): undefined reference to `SDL_GetWindowPixelFormat'
/usr/bin/ld: ltro1.c:(.text+0xde7): undefined reference to `SDL_PixelFormatEnumToMasks'
/usr/bin/ld: ltro1.c:(.text+0xe05): undefined reference to `SDL_CreateRenderer'
/usr/bin/ld: ltro1.c:(.text+0xe27): undefined reference to `SDL_RenderSetLogicalSize'
/usr/bin/ld: ltro1.c:(.text+0xe4d): undefined reference to `SDL_CreateTexture'
/usr/bin/ld: ltro1.c:(.text+0xe86): undefined reference to `SDL_CreateRGBSurface'
/usr/bin/ld: ltro1.c:(.text+0xeba): undefined reference to `SDL_CreateRGBSurface'
/usr/bin/ld: ltro1.c:(.text+0xee7): undefined reference to `SDL_SetPaletteColors'
/usr/bin/ld: ltro1.c:(.text+0xf0b): undefined reference to `SDL_memset'
/usr/bin/ld: ltro1.c:(.text+0xf1a): undefined reference to `SDL_memset'
/usr/bin/ld: ltro1.c:(.text+0xf4f): undefined reference to `SDL_OpenAudioDevice'
/usr/bin/ld: ltro1.c:(.text+0xfa3): undefined reference to `SDL_PauseAudioDevice'
/usr/bin/ld: ltro1.c:(.text+0xfe9): undefined reference to `SDL_GetTicks'
/usr/bin/ld: ltro1.c:(.text+0x1027): undefined reference to `SDL_PollEvent'
/usr/bin/ld: ltro1.c:(.text+0x10a0): undefined reference to `SDL_PollEvent'
/usr/bin/ld: ltro1.c:(.text+0x10ae): undefined reference to `SDL_GetTicks'
/usr/bin/ld: ltro1.c:(.text+0x1118): undefined reference to `SDL_FillRect'
/usr/bin/ld: ltro1.c:(.text+0x153c): undefined reference to `SDL_SetClipboardText'
/usr/bin/ld: ltro1.c:(.text+0x15ee): undefined reference to `SDL_SetRenderDrawColor'
/usr/bin/ld: ltro1.c:(.text+0x1602): undefined reference to `SDL_RenderClear'
/usr/bin/ld: ltro1.c:(.text+0x1621): undefined reference to `SDL_UpperBlit'
/usr/bin/ld: ltro1.c:(.text+0x1645): undefined reference to `SDL_UpdateTexture'
/usr/bin/ld: ltro1.c:(.text+0x1664): undefined reference to `SDL_RenderCopy'
/usr/bin/ld: ltro1.c:(.text+0x1678): undefined reference to `SDL_RenderPresent'
/usr/bin/ld: ltro1.c:(.text+0x1707): undefined reference to `SDL_GetError'
/usr/bin/ld: ltro1.c:(.text+0x1725): undefined reference to `SDL_GetError'
/usr/bin/ld: ltro1.c:(.text+0x1743): undefined reference to `SDL_GetError'
/usr/bin/ld: ltro1.c:(.text+0x1761): undefined reference to `SDL_GetError'
/usr/bin/ld: ltro1.c:(.text+0x177f): undefined reference to `SDL_GetError'
/usr/bin/ld: ltro1.c:(.text+0x179d): undefined reference to `SDL_GetClipboardText'
/usr/bin/ld: ltro1.c:(.text+0x17b3): undefined reference to `SDL_free'
/usr/bin/ld: ltro1.c:(.text+0x1812): undefined reference to `SDL_GetError'
/usr/bin/ld: ltro1.c:(.text+0x1830): undefined reference to `SDL_GetError'
/usr/bin/ld: ltro1.c:(.text+0x1887): undefined reference to `SDL_GetError'
/usr/bin/ld: ltro1.c:(.text+0x18a5): undefined reference to `SDL_GetError'
/usr/bin/ld: ltro1.c:(.text+0x18c3): undefined reference to `SDL_GetError'
/usr/bin/ld: ./src/ltro1.o:ltro1.c:(.text+0x18e1): more undefined references to `SDL_GetError' follow
/usr/bin/ld: ./src/ltro1.o: in function `main':
ltro1.c:(.text.startup+0xd1): undefined reference to `SDL_FreeSurface'
/usr/bin/ld: ltro1.c:(.text.startup+0xe2): undefined reference to `SDL_FreeSurface'
/usr/bin/ld: ltro1.c:(.text.startup+0xf3): undefined reference to `SDL_DestroyTexture'
/usr/bin/ld: ltro1.c:(.text.startup+0x104): undefined reference to `SDL_DestroyRenderer'
/usr/bin/ld: ltro1.c:(.text.startup+0x115): undefined reference to `SDL_DestroyWindow'
/usr/bin/ld: ltro1.c:(.text.startup+0x11a): undefined reference to `SDL_Quit'
/usr/bin/ld: ltro1.c:(.text.startup+0x15f): undefined reference to `SDL_ShowSimpleMessageBox'
/usr/bin/ld: ltro1.c:(.text.startup+0x169): undefined reference to `SDL_CloseAudioDevice'
/usr/bin/ld: ./lua/src/lmathlib.o: in function `math_tan':
lmathlib.c:(.text+0x6f): undefined reference to `tan'
/usr/bin/ld: ./lua/src/lmathlib.o: in function `math_sqrt':
lmathlib.c:(.text+0xbc): undefined reference to `sqrt'
/usr/bin/ld: ./lua/src/lmathlib.o: in function `math_sin':
lmathlib.c:(.text+0xdf): undefined reference to `sin'
/usr/bin/ld: ./lua/src/lmathlib.o: in function `math_log':
lmathlib.c:(.text+0x296): undefined reference to `log10'
/usr/bin/ld: lmathlib.c:(.text+0x2a6): undefined reference to `log'
/usr/bin/ld: lmathlib.c:(.text+0x2c8): undefined reference to `log2'
/usr/bin/ld: lmathlib.c:(.text+0x2dc): undefined reference to `log'
/usr/bin/ld: lmathlib.c:(.text+0x2f0): undefined reference to `log'
/usr/bin/ld: ./lua/src/lmathlib.o: in function `math_fmod':
lmathlib.c:(.text+0x39f): undefined reference to `fmod'
/usr/bin/ld: ./lua/src/lmathlib.o: in function `math_exp':
lmathlib.c:(.text+0x43f): undefined reference to `exp'
/usr/bin/ld: ./lua/src/lmathlib.o: in function `math_cos':
lmathlib.c:(.text+0x46f): undefined reference to `cos'
/usr/bin/ld: ./lua/src/lmathlib.o: in function `math_atan':
lmathlib.c:(.text+0x4cc): undefined reference to `atan2'
/usr/bin/ld: ./lua/src/lmathlib.o: in function `math_asin':
lmathlib.c:(.text+0x4ff): undefined reference to `asin'
/usr/bin/ld: ./lua/src/lmathlib.o: in function `math_acos':
lmathlib.c:(.text+0x52f): undefined reference to `acos'
/usr/bin/ld: ./lua/src/lobject.o: in function `numarith':
lobject.c:(.text+0x1a1): undefined reference to `pow'
/usr/bin/ld: ./lua/src/lvm.o: in function `luaV_modf':
lvm.c:(.text+0x156b): undefined reference to `fmod'
/usr/bin/ld: ./lua/src/lvm.o: in function `luaV_execute':
lvm.c:(.text+0x26b7): undefined reference to `fmod'
/usr/bin/ld: lvm.c:(.text+0x28d4): undefined reference to `pow'
/usr/bin/ld: lvm.c:(.text+0x3e5e): undefined reference to `pow'
collect2: error: ld returned 1 exit status
make: *** [Makefile.unix:9: default] Error 1
```

The following changes fixes these issues.